### PR TITLE
Limit TOC levels to 2

### DIFF
--- a/MarkdownTOC.py
+++ b/MarkdownTOC.py
@@ -42,7 +42,7 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
   def get_TOC(self, begin=0):
 
     # Search headings in docment
-    headings = self.view.find_all("^#+? ")
+    headings = self.view.find_all("^#{1,2}? ")
     
     items = [] # [[headingNum,text],...]
     for heading in headings:


### PR DESCRIPTION
(1) TOC can be REALLY long and 2 levels is generally enough. In my opinion the default should be 2 only. 
Hope you can check it in as is.

(2) However, if want N levels - can do {1,N}, then add Sublime Text settings for all (current code), or accept 1,2,3 for N.
