### PR TITLE
fix(autolink): remove 'double-quotes' from generated slug

### DIFF
--- a/MarkdownTOC.py
+++ b/MarkdownTOC.py
@@ -238,7 +238,8 @@ def remove_reserved_chars(str):
         ord(u"@"): None,
         ord(u"["): None,
         ord(u"]"): None,
-        ord(u"`"): None
+        ord(u"`"): None,
+        ord(u"\""): None,
     }
     return str.translate(delete)
 


### PR DESCRIPTION
Github removes the `"` from the generated IDs of headings
but this lib doesn't.
