### PR TITLE
fix(autolink): remove 'full-stop' from generated slug

### DIFF
--- a/MarkdownTOC.py
+++ b/MarkdownTOC.py
@@ -240,6 +240,7 @@ def remove_reserved_chars(str):
         ord(u"]"): None,
         ord(u"`"): None,
         ord(u"\""): None,
+        ord(u"."): None,
     }
     return str.translate(delete)
 


### PR DESCRIPTION
github removes `.` from the generated slug, so should this library.
