### PR TITLE
Fixed issue with substitutes and unicode.

### DIFF
--- a/MarkdownTOC.py
+++ b/MarkdownTOC.py
@@ -223,11 +223,11 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
         replacements = self.get_setting('id_replacements')
         # log(replacements)
         for _key in replacements:
-            _substitute = _key
+            _substitute = unicode(_key)
             _target_chars = replacements[_key]
             table = {}
             for char in _target_chars:
-                table[ord(char)] = _key
+                table[ord(char)] = _substitute
             _str = _str.translate(table)
         return _str
 


### PR DESCRIPTION
Previously I would get the following error, since only the values were in unicode.

```
Traceback (most recent call last):
  File "./sublime_plugin.py", line 362, in run_
  File "./MarkdownTOC.py", line 292, in run
  File "./MarkdownTOC.py", line 100, in find_tag_and_insert
  File "./MarkdownTOC.py", line 187, in get_toc
  File "./MarkdownTOC.py", line 232, in replace_chars_in_id
TypeError: character mapping must return integer, None or unicode
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/naokazuterada/markdowntoc/39)
<!-- Reviewable:end -->
