### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ This will be useful on Github.
 <!-- /MarkdownTOC -->
 ```
 
-#### Replecements for id charactors
+#### Replecements for id characters
 
 You can also edit replecements when using 'Auto link' feature like following settings.
 
@@ -175,7 +175,7 @@ This heading changes to link with following id.
 #super-product
 ```
 
-- The value charactor(s) will be replaced to the key charactor.
+- The value character(s) will be replaced to the key character.
 - Replece sequence will execute from top to bottom.
 
 


### PR DESCRIPTION
@naokazuterada, I've corrected a typographical error in the documentation of the [MarkdownTOC](https://github.com/naokazuterada/MarkdownTOC) project. Specifically, I've changed charactor to character. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/naokazuterada/markdowntoc/52)
<!-- Reviewable:end -->
