### PR TITLE
Fix typographical error(s)

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,7 +148,7 @@ This will be useful on Github.
 <!-- /MarkdownTOC -->
 ```
 
-#### Replecements for id charactors
+#### Replecements for id characters
 
 You can also edit replecements when using 'Auto link' feature like following settings.
 


### PR DESCRIPTION
@naokazuterada, I've corrected a typographical error in the documentation of the [MarkdownTOC](https://github.com/naokazuterada/MarkdownTOC) project. Specifically, I've changed charactors to characters. You should be able to merge this pull request automatically. However, if this was intentional or if you enjoy living in linguistic squalor, please let me know and [create an issue](https://github.com/thoppe/orthographic-pedant/issues/new) on my home repository.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/naokazuterada/markdowntoc/53)
<!-- Reviewable:end -->
