### PR TITLE
Removed automatic zero-indenting for first item in generated list for TOC, not respecting the actual Markdown header formatting.

### DIFF
--- a/MarkdownTOC.py
+++ b/MarkdownTOC.py
@@ -307,7 +307,6 @@ def format(items):
     if 1 < min_heading:
         for i, item in enumerate(headings):
             headings[i] -= min_heading - 1
-    headings[0] = 1  # first item must be 1
 
     # minimize "jump width"
     for i, item in enumerate(headings):


### PR DESCRIPTION
I know this might be considered a regression, but it bothers me that the rendered TOC does not respect the actual Markdown headers.

Currently a markdown list like:

### a

### b

Would render:

- a
    - b

Because the first element would have indentation reset.

This change allows you to do:

# TOC

<!-- MarkdownTOC —>
<!-- /MarkdownTOC -->

## a
## b

And have it rendered:

TOC

   - a
   - b

More intuitively.

Some users might find this problematic depending on their use case, but I prefer to have the Markdown shape the decision on the actual indentation.

Thanks for a marvellous plugin btw.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/naokazuterada/markdowntoc/65)
<!-- Reviewable:end -->
