### PR TITLE
Fix indent errors

### DIFF
--- a/MarkdownTOC.py
+++ b/MarkdownTOC.py
@@ -185,7 +185,7 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
 
             # Add indent
             for i in range(_indent):
-                toc += '\t'
+                toc += '    '
 
             # Reference-style links: e.g. '# heading [my-anchor]'
             list_reference_link = list(pattern_reference_link.finditer(_text))


### PR DESCRIPTION
Use 4 SPACE as indent prefix since sometimes TAB will be replaced by 2 SPACE rather than 4 SPACE, that will cause some markdown interpreters treat the  different levels list as a same one.

e.g. , 

Expect:

```
- h1
    -- h2
```
But returns:

```
- h1
  -- h2
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/naokazuterada/markdowntoc/66)
<!-- Reviewable:end -->
