### PR TITLE
Improved ATX headings

### DIFF
--- a/MarkdownTOC.py
+++ b/MarkdownTOC.py
@@ -125,7 +125,7 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
                     # handle hash headings, ### chapter 1
                     r = sublime.Region(
                         heading.end() - 1, self.view.line(heading).end())
-                    text = self.view.substr(r).strip().strip('#')
+                    text = self.view.substr(r).strip().rstrip('#')
                     indent = heading.size() - 1
                     items.append([indent, text, heading.begin()])
                 elif len(lines) == 2:

--- a/MarkdownTOC.py
+++ b/MarkdownTOC.py
@@ -124,8 +124,8 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
                 if len(lines) == 1:
                     # handle hash headings, ### chapter 1
                     r = sublime.Region(
-                        heading.end(), self.view.line(heading).end())
-                    text = self.view.substr(r)
+                        heading.end() - 1, self.view.line(heading).end())
+                    text = self.view.substr(r).strip().strip('#')
                     indent = heading.size() - 1
                     items.append([indent, text, heading.begin()])
                 elif len(lines) == 2:

--- a/tests/test_default.py
+++ b/tests/test_default.py
@@ -93,3 +93,39 @@ class TestDefault(TestBase):
 """
         toc_txt = self.commonSetup(text)
         self.assert_In('function\(foo\[, bar\]\)', toc_txt)
+
+    def test_spaces_in_atx_heading(self):
+        text = \
+"""
+
+
+#Heading 0
+
+#       Heading 1
+"""
+        toc_txt = self.commonSetup(text)
+        self.assert_In('- Heading 0', toc_txt)
+        self.assert_In('- Heading 1', toc_txt)
+
+    def test_remove_atx_closing_seq(self):
+        """ Remove closing sequence of # characters
+        """
+        text = \
+"""
+
+
+# Heading 0 #
+
+
+## Heading 1       ###
+
+
+# Heading 2 ##########
+
+
+## Heading 3
+"""
+        toc_txt = self.commonSetup(text)
+        self.assert_In('Heading 0\n', toc_txt)
+        self.assert_In('Heading 1\n', toc_txt)
+        self.assert_In('Heading 2\n', toc_txt)


### PR DESCRIPTION
### Extra spaces processing in headings, according [this document](http://spec.commonmark.org/0.26/#atx-headings)
```
#        Heading 0
```
before this patch:
```
-       Heading 0
```
after:
```
- Heading 0
```
At least one space is required between the # characters and the heading’s contents, but many implementations, github for example, currently do not require the space. 
```
#Heading 1
```
before:
```
-eading 1
```
after:
```
- Heading 1
```

### Removing of closing sequence of `#` characters
```
#### Heading 2 ####
```
before:
```
- Heading 2  ####
```
after:
```
- Heading 2
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/naokazuterada/markdowntoc/74)
<!-- Reviewable:end -->
