### PR TITLE
Add feature 'URI encoding'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 Changes in MarkdownTOC
 ===========================
 
+## 2.3.0
+
+- Add 'URI encoding' feature
+- Change 'default_lowercase_only_ascii' default value ('false' to 'true') because it breaks link in Russian
+
 ## 2.2.1
 
 - Improve heading detecting

--- a/MarkdownTOC.py
+++ b/MarkdownTOC.py
@@ -257,7 +257,7 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
         tag_str_html = pattern_toc_tag_start.sub("<", tag_str)
         tag_str_html = pattern_toc_tag_start.sub(">", tag_str_html)
 
-        soup = BeautifulSoup(tag_str_html)
+        soup = BeautifulSoup(tag_str_html, "html.parser")
 
         return soup.find('markdowntoc').attrs
 

--- a/MarkdownTOC.py
+++ b/MarkdownTOC.py
@@ -3,6 +3,7 @@ import sublime_plugin
 import re
 import os.path
 import pprint
+import urllib.parse
 from .bs4 import BeautifulSoup
 
 # for dbug
@@ -180,12 +181,17 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
                 _text = _text[0:match_ex_id.start()].rstrip()
                 _id = match_ex_id.group().replace('{#','').replace('}','')
             elif strtobool(attrs['autolink']):
+
                 if strtobool(attrs['lowercase_only_ascii']):
                     # only ascii
                     _lower_text = ''.join(chr(ord(x)+('A'<=x<='Z')*32) for x in _text)
                 else:
                     _lower_text = _text.lower()
                 _id = self.replace_strings_in_id(_lower_text)
+
+                if strtobool(attrs['uri_encode']):
+                    _id = urllib.parse.quote(_id)
+
                 _ids.append(_id)
                 n = _ids.count(_id)
                 if 1 < n:
@@ -248,7 +254,8 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
             "depth":                self.get_setting('default_depth'),
             "indent":               self.get_setting('default_indent'),
             "lowercase_only_ascii": self.get_setting('default_lowercase_only_ascii'),
-            "style":                self.get_setting('default_style')
+            "style":                self.get_setting('default_style'),
+            "uri_encode":           self.get_setting('default_uri_encode')
         }
 
     def get_attibutes_from(self, tag_str):

--- a/MarkdownTOC.py
+++ b/MarkdownTOC.py
@@ -189,7 +189,7 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
                     _lower_text = _text.lower()
                 _id = self.replace_strings_in_id(_lower_text)
 
-                if strtobool(attrs['uri_encode']):
+                if strtobool(attrs['uri_encoding']):
                     _id = urllib.parse.quote(_id)
 
                 _ids.append(_id)
@@ -255,7 +255,7 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
             "indent":               self.get_setting('default_indent'),
             "lowercase_only_ascii": self.get_setting('default_lowercase_only_ascii'),
             "style":                self.get_setting('default_style'),
-            "uri_encode":           self.get_setting('default_uri_encode')
+            "uri_encoding":           self.get_setting('default_uri_encoding')
         }
 
     def get_attibutes_from(self, tag_str):

--- a/MarkdownTOC.sublime-settings
+++ b/MarkdownTOC.sublime-settings
@@ -6,7 +6,7 @@
   "default_indent": "\t",
   "default_lowercase_only_ascii": false,
   "default_style": "unordered",
-  "default_uri_encode": true,
+  "default_uri_encoding": true,
   "id_replacements": {
     "-": " ",
     "" : ["&lt;","&gt;","&amp;","&apos;","&quot;","&#60;","&#62;","&#38;","&#39;","&#34;","!","#","$","&","'","(",")","*","+",",","/",":",";","=","_","?","@","[","]","`","\"", ".","<",">","{","}","™","®","©"]

--- a/MarkdownTOC.sublime-settings
+++ b/MarkdownTOC.sublime-settings
@@ -4,7 +4,7 @@
   "default_bracket": "square",
   "default_depth": 2,
   "default_indent": "\t",
-  "default_lowercase_only_ascii": false,
+  "default_lowercase_only_ascii": true,
   "default_style": "unordered",
   "default_uri_encoding": true,
   "id_replacements": {

--- a/MarkdownTOC.sublime-settings
+++ b/MarkdownTOC.sublime-settings
@@ -6,6 +6,7 @@
   "default_indent": "\t",
   "default_lowercase_only_ascii": false,
   "default_style": "unordered",
+  "default_uri_encode": true,
   "id_replacements": {
     "-": " ",
     "" : ["&lt;","&gt;","&amp;","&apos;","&quot;","&#60;","&#62;","&#38;","&#39;","&#34;","!","#","$","&","'","(",")","*","+",",","/",":",";","=","_","?","@","[","]","`","\"", ".","<",">","{","}","™","®","©"]

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Sublime Text 3 plugin for generating a Table of Contents (TOC) in a Markdown doc
     - [Auto linking for _clickable_ TOC](#auto-linking-for-clickable-toc)
         - [Lowercase only ASCII characters in auto link ids](#lowercase-only-ascii-characters-in-auto-link-ids)
         - [Manipulation of auto link ids](#manipulation-of-auto-link-ids)
+        - [URI encoding](#uri-encoding)
     - [Control of depth listed in TOC](#control-of-depth-listed-in-toc)
     - [Ordered or unordered style for TOC elements](#ordered-or-unordered-style-for-toc-elements)
     - [Specify custom indentation prefix](#specify-custom-indentation-prefix)
@@ -359,6 +360,44 @@ This heading link of this heading is changed to following id
 - The `' '` (space) is replaced with `-` (dash), since `' '` is included in the first set
 - The '™' is replaced with _nothing_, since '™' is included in the second set
 
+#### URI encoding
+
+Non-ascii characters within link ids would be [URL encoded](https://en.wikipedia.org/wiki/Percent-encoding) default.
+
+```
+<!-- MarkdownTOC autolink="true" -->
+
+- [Ejemplos de español][ejemplos-de-espa%C3%B1ol]
+- [日本語の例][%E6%97%A5%E6%9C%AC%E8%AA%9E%E3%81%AE%E4%BE%8B]
+- [Примеры русского][%D0%9F%D1%80%D0%B8%D0%BC%D0%B5%D1%80%D1%8B-%D1%80%D1%83%D1%81%D1%81%D0%BA%D0%BE%D0%B3%D0%BE]
+- [中国的例子][%E4%B8%AD%E5%9B%BD%E7%9A%84%E4%BE%8B%E5%AD%90]
+
+<!-- /MarkdownTOC -->
+
+# Ejemplos de español
+# 日本語の例
+# Примеры русского
+# 中国的例子
+```
+
+But you can also disable this with `uri_encoding="false"` attribute.
+
+```
+<!-- MarkdownTOC autolink="true" uri_encoding="false" -->
+
+- [Ejemplos de español][ejemplos-de-español]
+- [日本語の例][日本語の例]
+- [Примеры русского][Примеры-русского]
+- [中国的例子][中国的例子]
+
+<!-- /MarkdownTOC -->
+
+# Ejemplos de español
+# 日本語の例
+# Примеры русского
+# 中国的例子
+```
+
 ### Control of depth listed in TOC
 
 ```
@@ -562,6 +601,7 @@ The following attributes can be used to control the generation of the TOC.
 | [indent](#indent)                             | string                         | `'\t'`        | `default_indent`               |
 | [lowercase_only_ascii](#lowercase_only_ascii) | `true`or`false`                | `true`        | `default_lowercase_only_ascii` |
 | [style](#style)                               | `ordered` or `unordered`       | `'unordered'` | `default_style`                |
+| [uri_encoding](#uri_encoding)                 | `true`or`false`                | `true`        | `default_uri_encoding`         |
 
 You can define your own default values via package preferences, [Sublime Text][SublimeText]s way of letting users customize [package settings][SublimeTextSettings]. Please see the [Section on Configuration](#Configuration) for more details for **MarkdownTOC**.
 
@@ -605,6 +645,7 @@ Example: `MarkdownTOC.sublime-settings`
   "default_indent": "\t",
   "default_lowercase_only_ascii": true,
   "default_style": "unordered",
+  "default_uri_encoding": true,
   "id_replacements": {
     "-": " ",
     "" : ["&lt;","&gt;","&amp;","&apos;","&quot;","&#60;","&#62;","&#38;","&#39;","&#34;","!","#","$","&","'","(",")","*","+",",","/",":",";","=","?","@","[","]","`","\"", ".","<",">","{","}","™","®","©"]
@@ -629,6 +670,7 @@ For an overview of the specific behaviour behind an attribute, please refer to t
 - `default_indent`, (see: [Specify custom indentation prefix](#specify-custom-indentation-prefix))
 - `default_lowercase_only_ascii`, (see: [Lowercase only ASCII characters in auto link ids](#lowercase-only-ascii-characters-in-auto-link-ids))
 - `default_style`, (see: [Ordered or unordered style for TOC elements](#ordered-or-unordered-style-for-toc-elements))
+- `default_uri_encoding`, (see: [URI encoding](#uri-encoding))
 - `id_replacements`, (see: [Manipulation of auto link ids](#manipulation-of-auto-link-ids))
 
 ### Github Configuration

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Please note that the default for bracket is `square` defined by the [attribute](
 
 #### Lowercase only ASCII characters in auto link ids
 
-The plugin lowercase **only ascii alphabets**(`a` to `z`) within auto link ids default.
+By default the plugin lowercases **ASCII based alphabets only (`a` to `z`)** for auto links.
 
 ```
 <!-- MarkdownTOC autolink="true" -->
@@ -317,7 +317,7 @@ The plugin lowercase **only ascii alphabets**(`a` to `z`) within auto link ids d
 # ПРИМЕР EXAMPLE
 ```
 
-But you can also expand its target all alphabets with `lowercase_only_ascii="false"` attribute.
+You can expand the lowercasing capability by setting the `lowecase_only_ascii` attribute to `false`.
 
 ```
 <!-- MarkdownTOC autolink="true" lowercase_only_ascii="false" -->
@@ -362,7 +362,7 @@ This heading link of this heading is changed to following id
 
 #### URI encoding
 
-Non-ascii characters within link ids would be [URL encoded](https://en.wikipedia.org/wiki/Percent-encoding) default.
+By default non-ASCII characters in link ids are [URL encoded](https://en.wikipedia.org/wiki/Percent-encoding).
 
 ```
 <!-- MarkdownTOC autolink="true" -->
@@ -380,7 +380,7 @@ Non-ascii characters within link ids would be [URL encoded](https://en.wikipedia
 # 中国的例子
 ```
 
-But you can also disable this with `uri_encoding="false"` attribute.
+As mentioned you can disable this by setting the `uri_encoding` attribute to `false`, like so: `uri_encoding="false"`.
 
 ```
 <!-- MarkdownTOC autolink="true" uri_encoding="false" -->

--- a/README.md
+++ b/README.md
@@ -305,7 +305,7 @@ Please note that the default for bracket is `square` defined by the [attribute](
 
 #### Lowercase only ASCII characters in auto link ids
 
-By default the plugin lowercases **ASCII based alphabets only (`a` to `z`)** for auto links.
+By default the plugin lowercases ASCII based alphabets **only** (`a` to `z`) for auto links.
 
 ```
 <!-- MarkdownTOC autolink="true" -->

--- a/README.md
+++ b/README.md
@@ -622,12 +622,12 @@ Configuration precendence is as follows:
 
 For an overview of the specific behaviour behind an attribute, please refer to the below list.
 
-- `default_autolink`, (see: [Auto linking for _clickable_ TOC](#auto-linking-for-_clickable_-toc))
+- `default_autolink`, (see: [Auto linking for _clickable_ TOC](#auto-linking-for-clickable-toc))
 - `default_autoanchor`, (see: [Auto anchoring when heading has anchor defined](#auto-anchoring-when-heading-has-anchor-defined))
-- `default_bracket`, (see: [Auto linking for _clickable_ TOC](#auto-linking-for-_clickable_-toc))
+- `default_bracket`, (see: [Auto linking for _clickable_ TOC](#auto-linking-for-clickable-toc))
 - `default_depth`, (see: [Control of depth listed in TOC](#control-of-depth-listed-in-toc))
 - `default_indent`, (see: [Specify custom indentation prefix](#specify-custom-indentation-prefix))
-- `default_lowercase_only_ascii`, (see: [Lowercase only ASCII characters in anchor](#lowercase-only-ascii-characters-in-anchor))
+- `default_lowercase_only_ascii`, (see: [Lowercase only ASCII characters in auto link ids](#lowercase-only-ascii-characters-in-auto-link-ids))
 - `default_style`, (see: [Ordered or unordered style for TOC elements](#ordered-or-unordered-style-for-toc-elements))
 - `id_replacements`, (see: [Manipulation of auto link ids](#manipulation-of-auto-link-ids))
 

--- a/README.md
+++ b/README.md
@@ -304,24 +304,24 @@ Please note that the default for bracket is `square` defined by the [attribute](
 
 #### Lowercase only ASCII characters in auto link ids
 
-The plugin lowercase all alphabets within auto link ids default.
+The plugin lowercase **only ascii alphabets**(`a` to `z`) within auto link ids default.
 
 ```
-<!-- MarkdownTOC autolink=true -->
+<!-- MarkdownTOC autolink="true" -->
 
-- [ПРИМЕР EXAMPLE][пример-example]
+- [ПРИМЕР EXAMPLE][ПРИМЕР-example]
 
 <!-- /MarkdownTOC -->
 
 # ПРИМЕР EXAMPLE
 ```
 
-But you can also squeeze its target **only ascii alphabets**(`a` to `z`) with `lowercase_only_ascii=true` attribute.
+But you can also expand its target all alphabets with `lowercase_only_ascii="false"` attribute.
 
 ```
-<!-- MarkdownTOC autolink=true lowercase_only_ascii=true -->
+<!-- MarkdownTOC autolink="true" lowercase_only_ascii="false" -->
 
-- [ПРИМЕР EXAMPLE][ПРИМЕР-example]
+- [ПРИМЕР EXAMPLE][пример-example]
 
 <!-- /MarkdownTOC -->
 
@@ -560,7 +560,7 @@ The following attributes can be used to control the generation of the TOC.
 | [bracket](#bracket)                           | `square`or`round`              | `'square'`    | `default_bracket`              |
 | [depth](#depth)                               | integer (`0` means _no limit_) | `2`           | `default_depth`                |
 | [indent](#indent)                             | string                         | `'\t'`        | `default_indent`               |
-| [lowercase_only_ascii](#lowercase_only_ascii) | `true`or`false`                | `false`       | `default_lowercase_only_ascii` |
+| [lowercase_only_ascii](#lowercase_only_ascii) | `true`or`false`                | `true`        | `default_lowercase_only_ascii` |
 | [style](#style)                               | `ordered` or `unordered`       | `'unordered'` | `default_style`                |
 
 You can define your own default values via package preferences, [Sublime Text][SublimeText]s way of letting users customize [package settings][SublimeTextSettings]. Please see the [Section on Configuration](#Configuration) for more details for **MarkdownTOC**.
@@ -603,7 +603,7 @@ Example: `MarkdownTOC.sublime-settings`
   "default_bracket": "square",
   "default_depth": 2,
   "default_indent": "\t",
-  "default_lowercase_only_ascii": false,
+  "default_lowercase_only_ascii": true,
   "default_style": "unordered",
   "id_replacements": {
     "-": " ",

--- a/messages.json
+++ b/messages.json
@@ -10,4 +10,5 @@
   ,"2.0.0":   "messages/2.0.0.txt"
   ,"2.2.0":   "messages/2.2.0.txt"
   ,"2.2.1":   "messages/2.2.1.txt"
+  ,"2.3.0":   "messages/2.3.0.txt"
 }

--- a/messages/2.3.0.txt
+++ b/messages/2.3.0.txt
@@ -1,0 +1,6 @@
+MarkdownTOC - 2.3.0
+
+CHANGES
+
+- Add 'URI encoding' feature
+- Change 'default_lowercase_only_ascii' default value ('false' to 'true') because it breaks link in Russian

--- a/tests/test_attribute.py
+++ b/tests/test_attribute.py
@@ -260,7 +260,7 @@ class TestAttribute(TestBase):
 
     def test_lowercase_only_ascii_default(self):
         toc_txt = self.commonSetup(self.lowercase_only_ascii_text.format('autolink=true'))
-        self.assert_In('- [ПРИМЕР EXAMPLE][пример-example]', toc_txt)
+        self.assert_In('- [ПРИМЕР EXAMPLE][ПРИМЕР-example]', toc_txt)
 
     def test_lowercase_only_ascii_true(self):
         toc_txt = self.commonSetup(self.lowercase_only_ascii_text.format('autolink=true lowercase_only_ascii=true'))

--- a/tests/test_attribute.py
+++ b/tests/test_attribute.py
@@ -251,7 +251,7 @@ class TestAttribute(TestBase):
     lowercase_only_ascii_text = \
 """
 
-<!-- MarkdownTOC uri_encode=false {0} -->
+<!-- MarkdownTOC uri_encoding=false {0} -->
 
 <!-- /MarkdownTOC -->
 
@@ -273,7 +273,7 @@ class TestAttribute(TestBase):
     # -----------------
     # URI encode
 
-    uri_encode_text = \
+    uri_encoding_text = \
 """
 
 <!-- MarkdownTOC autolink=true lowercase_only_ascii=true {0} -->
@@ -287,24 +287,24 @@ class TestAttribute(TestBase):
 # 一个标题
 """
 
-    def test_uri_encode_default(self):
-        toc_txt = self.commonSetup(self.uri_encode_text.format(''))
+    def test_uri_encoding_default(self):
+        toc_txt = self.commonSetup(self.uri_encoding_text.format(''))
         self.assert_In('- [Camión, último][cami%C3%B3n-%C3%BAltimo]', toc_txt)
         self.assert_In('- [España][espa%C3%B1a]', toc_txt)
         self.assert_In('- [こんにちわ 世界][%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%82%8F-%E4%B8%96%E7%95%8C]', toc_txt)
         self.assert_In('- [Пример Example][%D0%9F%D1%80%D0%B8%D0%BC%D0%B5%D1%80-example]', toc_txt)
         self.assert_In('- [一个标题][%E4%B8%80%E4%B8%AA%E6%A0%87%E9%A2%98]', toc_txt)
 
-    def test_uri_encode_true(self):
-        toc_txt = self.commonSetup(self.uri_encode_text.format('uri_encode=true'))
+    def test_uri_encoding_true(self):
+        toc_txt = self.commonSetup(self.uri_encoding_text.format('uri_encoding=true'))
         self.assert_In('- [Camión, último][cami%C3%B3n-%C3%BAltimo]', toc_txt)
         self.assert_In('- [España][espa%C3%B1a]', toc_txt)
         self.assert_In('- [こんにちわ 世界][%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%82%8F-%E4%B8%96%E7%95%8C]', toc_txt)
         self.assert_In('- [Пример Example][%D0%9F%D1%80%D0%B8%D0%BC%D0%B5%D1%80-example]', toc_txt)
         self.assert_In('- [一个标题][%E4%B8%80%E4%B8%AA%E6%A0%87%E9%A2%98]', toc_txt)
 
-    def test_uri_encode_false(self):
-        toc_txt = self.commonSetup(self.uri_encode_text.format('uri_encode=false'))
+    def test_uri_encoding_false(self):
+        toc_txt = self.commonSetup(self.uri_encoding_text.format('uri_encoding=false'))
         self.assert_In('- [Camión, último][camión-último]', toc_txt)
         self.assert_In('- [España][españa]', toc_txt)
         self.assert_In('- [こんにちわ 世界][こんにちわ-世界]', toc_txt)

--- a/tests/test_attribute.py
+++ b/tests/test_attribute.py
@@ -251,7 +251,7 @@ class TestAttribute(TestBase):
     lowercase_only_ascii_text = \
 """
 
-<!-- MarkdownTOC {0} -->
+<!-- MarkdownTOC uri_encode=false {0} -->
 
 <!-- /MarkdownTOC -->
 
@@ -269,3 +269,44 @@ class TestAttribute(TestBase):
     def test_lowercase_only_ascii_false(self):
         toc_txt = self.commonSetup(self.lowercase_only_ascii_text.format('autolink=true lowercase_only_ascii=false'))
         self.assert_In('- [ПРИМЕР EXAMPLE][пример-example]', toc_txt)
+
+    # -----------------
+    # URI encode
+
+    uri_encode_text = \
+"""
+
+<!-- MarkdownTOC autolink=true lowercase_only_ascii=true {0} -->
+
+<!-- /MarkdownTOC -->
+
+# Camión, último
+# España
+# こんにちわ 世界
+# Пример Example
+# 一个标题
+"""
+
+    def test_uri_encode_default(self):
+        toc_txt = self.commonSetup(self.uri_encode_text.format(''))
+        self.assert_In('- [Camión, último][cami%C3%B3n-%C3%BAltimo]', toc_txt)
+        self.assert_In('- [España][espa%C3%B1a]', toc_txt)
+        self.assert_In('- [こんにちわ 世界][%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%82%8F-%E4%B8%96%E7%95%8C]', toc_txt)
+        self.assert_In('- [Пример Example][%D0%9F%D1%80%D0%B8%D0%BC%D0%B5%D1%80-example]', toc_txt)
+        self.assert_In('- [一个标题][%E4%B8%80%E4%B8%AA%E6%A0%87%E9%A2%98]', toc_txt)
+
+    def test_uri_encode_true(self):
+        toc_txt = self.commonSetup(self.uri_encode_text.format('uri_encode=true'))
+        self.assert_In('- [Camión, último][cami%C3%B3n-%C3%BAltimo]', toc_txt)
+        self.assert_In('- [España][espa%C3%B1a]', toc_txt)
+        self.assert_In('- [こんにちわ 世界][%E3%81%93%E3%82%93%E3%81%AB%E3%81%A1%E3%82%8F-%E4%B8%96%E7%95%8C]', toc_txt)
+        self.assert_In('- [Пример Example][%D0%9F%D1%80%D0%B8%D0%BC%D0%B5%D1%80-example]', toc_txt)
+        self.assert_In('- [一个标题][%E4%B8%80%E4%B8%AA%E6%A0%87%E9%A2%98]', toc_txt)
+
+    def test_uri_encode_false(self):
+        toc_txt = self.commonSetup(self.uri_encode_text.format('uri_encode=false'))
+        self.assert_In('- [Camión, último][camión-último]', toc_txt)
+        self.assert_In('- [España][españa]', toc_txt)
+        self.assert_In('- [こんにちわ 世界][こんにちわ-世界]', toc_txt)
+        self.assert_In('- [Пример Example][Пример-example]', toc_txt)
+        self.assert_In('- [一个标题][一个标题]', toc_txt)


### PR DESCRIPTION
Hi, @jonasbn.

I really appreciate you to respond with issues!

I added a new feature 'URI encoding' upon requests. I think it may fix the problems of #79 and #56.
And I've also changed default value of 'default_lowercase_only_ascii' because it sometimes breaks link in languages which has non-ascii alphabets.

Could you review it especially sentences on README?