### PR TITLE
Add 'Markdown Numbered Headers' link to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -753,7 +753,7 @@ Here follows a list of other Markdown Table of Contents generators, for inspirat
 
 ### Recommended plugins for use with **MarkdownTOC**
 
-- [Markdown Numbered Headers](https://packagecontrol.io/packages/Markdown%20Numbered%20Headers) Sublime Text 3 plugin for markdown, auto insert/update/remove header numbers
+- [Markdown Numbered Headers](https://packagecontrol.io/packages/Markdown%20Numbered%20Headers) Sublime Text 3 plugin for Markdown, auto insert/update/remove header numbers
 
 [Markdown]: http://daringfireball.net/projects/markdown/syntax
 [MarkdownLinks]: http://daringfireball.net/projects/markdown/syntax#link

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ Sublime Text 3 plugin for generating a Table of Contents (TOC) in a Markdown doc
 - [Author](#author)
 - [References](#references)
     - [Markdown Table of Contents Generators](#markdown-table-of-contents-generators)
-    - [Recommended plugin for use with **MarkdownTOC**](#recommended-plugin-for-use-with-markdowntoc)
+    - [Recommended plugins for use with **MarkdownTOC**](#recommended-plugins-for-use-with-markdowntoc)
 
 <!-- /MarkdownTOC -->
 
@@ -751,7 +751,7 @@ Here follows a list of other Markdown Table of Contents generators, for inspirat
 - [doctoc](https://github.com/thlorenz/doctoc) Node (npm) implementation with CLI interface
 - [markdown-toclify](https://github.com/rasbt/markdown-toclify) Python implementation with CLI interface
 
-### Recommended plugin for use with **MarkdownTOC**
+### Recommended plugins for use with **MarkdownTOC**
 
 - [Markdown Numbered Headers](https://packagecontrol.io/packages/Markdown%20Numbered%20Headers) Sublime Text 3 plugin for markdown, auto insert/update/remove header numbers
 

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Sublime Text 3 plugin for generating a Table of Contents (TOC) in a Markdown doc
 - [Author](#author)
 - [References](#references)
     - [Markdown Table of Contents Generators](#markdown-table-of-contents-generators)
+    - [Recommended plugin for use with **MarkdownTOC**](#recommended-plugin-for-use-with-markdowntoc)
 
 <!-- /MarkdownTOC -->
 
@@ -749,6 +750,10 @@ Here follows a list of other Markdown Table of Contents generators, for inspirat
 
 - [doctoc](https://github.com/thlorenz/doctoc) Node (npm) implementation with CLI interface
 - [markdown-toclify](https://github.com/rasbt/markdown-toclify) Python implementation with CLI interface
+
+### Recommended plugin for use with **MarkdownTOC**
+
+- [Markdown Numbered Headers](https://packagecontrol.io/packages/Markdown%20Numbered%20Headers) Sublime Text 3 plugiin for markdown, auto insert/update/remove header numbers
 
 [Markdown]: http://daringfireball.net/projects/markdown/syntax
 [MarkdownLinks]: http://daringfireball.net/projects/markdown/syntax#link

--- a/README.md
+++ b/README.md
@@ -753,7 +753,7 @@ Here follows a list of other Markdown Table of Contents generators, for inspirat
 
 ### Recommended plugin for use with **MarkdownTOC**
 
-- [Markdown Numbered Headers](https://packagecontrol.io/packages/Markdown%20Numbered%20Headers) Sublime Text 3 plugiin for markdown, auto insert/update/remove header numbers
+- [Markdown Numbered Headers](https://packagecontrol.io/packages/Markdown%20Numbered%20Headers) Sublime Text 3 plugin for markdown, auto insert/update/remove header numbers
 
 [Markdown]: http://daringfireball.net/projects/markdown/syntax
 [MarkdownLinks]: http://daringfireball.net/projects/markdown/syntax#link


### PR DESCRIPTION
<!--
You should use unit-tests for SublimeText by using [UnitTesting](https://github.com/randy3k/UnitTesting) plugin.

1. Install the UnitTesting plugin
2. Comment out or rename your own `MarkdownTOC.sublime-settings` so individual settings are not used during testing
3. [Run tests](https://github.com/randy3k/UnitTesting-example#running-tests)
4. Send Pull Request when tests pass
-->

@jonasbn 

Hello, please review my PR.
In according to [this comment](https://github.com/naokazuterada/MarkdownTOC/issues/91#issuecomment-300362181), I want to add link for that plugin. Please let me know if there are more suitable section or titles for adding it.

Thanks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/naokazuterada/markdowntoc/97)
<!-- Reviewable:end -->
