### PR TITLE
Add `link_prefix` parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changes in MarkdownTOC
 ===========================
 
+## 2.7.0
+
+- Add `link_prefix` parameter. Ref: #54
+
 ## 2.6.0
 
 - Add `remove_image` parameter. Ref: #43

--- a/MarkdownTOC.py
+++ b/MarkdownTOC.py
@@ -262,6 +262,7 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
         _ids = []
         level_counters = [0]
         remove_image = strtobool(attrs['remove_image'])
+        link_prefix = attrs['link_prefix']
         list_bullets = attrs['list_bullets']
 
         for item in items:
@@ -336,6 +337,8 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
             # escape brackets
             _text = self.escape_brackets(_text)
 
+            _id = link_prefix+_id
+
             if _id == None:
                 toc += list_prefix + _text + '\n'
             elif attrs['bracket'] == 'round':
@@ -381,6 +384,7 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
             "depth":                self.get_setting('default_depth'),
             "remove_image":         self.get_setting('default_remove_image'),
             "indent":               self.get_setting('default_indent'),
+            "link_prefix":          self.get_setting('default_link_prefix'),
             "list_bullets":         self.get_setting('default_list_bullets'),
             "lowercase":            self.get_setting('default_lowercase'),
             "lowercase_only_ascii": self.get_setting('default_lowercase_only_ascii'),

--- a/MarkdownTOC.py
+++ b/MarkdownTOC.py
@@ -337,7 +337,8 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
             # escape brackets
             _text = self.escape_brackets(_text)
 
-            _id = link_prefix+_id
+            if link_prefix:
+                _id = link_prefix+_id
 
             if _id == None:
                 toc += list_prefix + _text + '\n'

--- a/MarkdownTOC.sublime-settings
+++ b/MarkdownTOC.sublime-settings
@@ -5,6 +5,7 @@
   "default_depth": 2,
   "default_indent": "\t",
   "default_remove_image": true,
+  "default_link_prefix": "",
   "default_list_bullets": "-",
   "default_lowercase": true,
   "default_lowercase_only_ascii": true,

--- a/README.md
+++ b/README.md
@@ -739,10 +739,10 @@ The following attributes can be used to control the generation of the TOC.
 |:---------------------- |:------------------------------ |:------------- |:------------------------------ |
 | `autoanchor`           | `true`or`false`                | `false`       | `default_autoanchor`           |
 | `autolink`             | `true`or`false`                | `false`       | `default_autolink`             |
-| `bracket`              | `square`or`round`              | `square`      | `default_bracket`              |
+| `bracket`              | `square`or`round`              | `"square"`    | `default_bracket`              |
 | `depth`                | integer (`0` means _no limit_) | `2`           | `default_depth`                |
-| `indent`               | string                         | `\t`          | `default_indent`               |
-| `list_bullets`         | string                         | `-`           | `default_list_bullets`         |
+| `indent`               | string                         | `"\t"`        | `default_indent`               |
+| `link_prefix`          | string                         | `""`          | `default_link_prefix`          |
 | `lowercase`            | `true`or`false`                | `true`        | `default_lowercase`            |
 | `lowercase_only_ascii` | `true`or`false`                | `true`        | `default_lowercase_only_ascii` |
 | `remove_image`         | `true`or`false`                | `true`        | `default_remove_image`         |

--- a/README.md
+++ b/README.md
@@ -638,7 +638,7 @@ You can set your default indentation in your [configuration](#configuration) wit
 
 If you want to preserve images in headings, set `remove_image` to `false`.
 
-```
+```markdown
 <!-- MarkdownTOC remove_image="false" -->
 
 - ![check](check.png) Everything is OK
@@ -650,7 +650,7 @@ If you want to preserve images in headings, set `remove_image` to `false`.
 
 Please note that the default for the [attribute](#attributes) is: `false`.
 
-```
+```markdown
 <!-- MarkdownTOC -->
 
 - Everything is OK

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Sublime Text 3 plugin for generating a Table of Contents (TOC) in a Markdown doc
         - [Manipulation of auto link ids](#manipulation-of-auto-link-ids)
         - [URI encoding](#uri-encoding)
         - [Markdown Preview compatible](#markdown-preview-compatible)
+        - [Link Prefix](#link-prefix)
     - [Control of depth listed in TOC](#control-of-depth-listed-in-toc)
     - [Ordered or unordered style for TOC elements](#ordered-or-unordered-style-for-toc-elements)
     - [Customizable list bullets in TOC](#customizable-list-bullets-in-toc)
@@ -82,6 +83,7 @@ The **MarkdownTOC** plugin is rich on features and customization, useful for bot
 - Ordered or unordered style for TOC elements
 - Customizable list bullets in TOC
 - Specify custom indentation prefix
+- Customizable link prefix
 
 ### Insertion of TOC based on headings in Markdown document
 
@@ -464,6 +466,22 @@ Currently no other parsers are supported.
 If you want to disable this feature, set it to `false`.
 
 
+#### Link Prefix
+
+You can also set _prefix_ of links.
+
+```markdown
+<!-- MarkdownTOC autolink=true link_prefix="user-content-" -->
+
+- [My Heading][user-content-my-heading]
+
+<!-- /MarkdownTOC -->
+
+# My Heading
+```
+
+You can manipulate this in your [configuration](#configuration) using the key `default_link_prefix`.
+
 ### Control of depth listed in TOC
 
 ```markdown
@@ -743,6 +761,7 @@ The following attributes can be used to control the generation of the TOC.
 | `depth`                | integer (`0` means _no limit_) | `2`           | `default_depth`                |
 | `indent`               | string                         | `"\t"`        | `default_indent`               |
 | `link_prefix`          | string                         | `""`          | `default_link_prefix`          |
+| `list_bullets`         | string                         | `"-"`         | `default_list_bullets`         |
 | `lowercase`            | `true`or`false`                | `true`        | `default_lowercase`            |
 | `lowercase_only_ascii` | `true`or`false`                | `true`        | `default_lowercase_only_ascii` |
 | `remove_image`         | `true`or`false`                | `true`        | `default_remove_image`         |
@@ -790,6 +809,7 @@ Example: `MarkdownTOC.sublime-settings`
   "default_bracket": "square",
   "default_depth": 2,
   "default_indent": "\t",
+  "default_link_prefix": "",
   "default_list_bullets": "-",
   "default_lowercase": true,
   "default_lowercase_only_ascii": true,
@@ -819,6 +839,7 @@ For an overview of the specific behaviour behind an attribute, please refer to t
 - `default_bracket`, (see: [Auto linking for _clickable_ TOC](#auto-linking-for-clickable-toc))
 - `default_depth`, (see: [Control of depth listed in TOC](#control-of-depth-listed-in-toc))
 - `default_indent`, (see: [Specify custom indentation prefix](#specify-custom-indentation-prefix))
+- `default_link_prefix`, (see: [Link Prefix](#link-prefix))
 - `default_list_bullets`, (see: [Customizable list bullets in TOC](#customizable-list-bullets-in-toc))
 - `default_lowercase`, (see: [Preserve case](#preserve-case))
 - `default_lowercase_only_ascii`, (see: [Lowercase only ASCII characters in auto link ids](#lowercase-only-ascii-characters-in-auto-link-ids))

--- a/messages/2.7.0.txt
+++ b/messages/2.7.0.txt
@@ -1,0 +1,5 @@
+MarkdownTOC - 2.7.0
+
+## Changes
+
+- Add `link_prefix` parameter. Ref: #54

--- a/tests/link_prefix.py
+++ b/tests/link_prefix.py
@@ -1,0 +1,27 @@
+# coding:utf-8
+from base import TestBase
+import sublime
+import sys
+
+class LinkPrefixBullets(TestBase):
+    """Test of attributes 'link_prefix'"""
+
+    # for debug
+    # def tearDown(self):
+    #     pass
+
+    link_prefix_text = \
+"""
+
+<!-- MarkdownTOC autolink="true" {0} -->
+
+<!-- /MarkdownTOC -->
+
+# My Beatutiful Heading
+"""
+    def test_link_prefix_default(self):
+        toc_txt = self.commonSetup(self.link_prefix_text.format(''))
+        self.assert_In('- [My Beatutiful Heading][my-beatutiful-heading]', toc_txt)
+    def test_link_prefix_1(self):
+        toc_txt = self.commonSetup(self.link_prefix_text.format('link_prefix="user-content-"'))
+        self.assert_In('- [My Beatutiful Heading][user-content-my-beatutiful-heading]', toc_txt)


### PR DESCRIPTION
Hi @jonasbn, I added new parameter `link_prefix`. Please review it.

## Changes

- Add `link_prefix` parameter. Ref: #54 

---

BTW, I'm also working on [these issues](https://github.com/naokazuterada/MarkdownTOC/milestone/1). These contain some breaking changes. So I'm planning to release those as version 3. I will need your help a lot on it too.

Thank you for your help! :wave: