### PR TITLE
[Fix] Replace name attribute to id

### DIFF
--- a/MarkdownTOC.py
+++ b/MarkdownTOC.py
@@ -1,23 +1,27 @@
-import sublime
-import sublime_plugin
-import re
 import os.path
 import pprint
+import re
+import sublime
+import sublime_plugin
 import sys
-from urllib.parse import quote
 import unicodedata
+
+from urllib.parse import quote
 
 # for debug
 pp = pprint.PrettyPrinter(indent=4)
 
-PATTERN_REFERENCE_LINK = re.compile(r'\[.+?\]$') # [Heading][my-id]
-PATTERN_IMAGE = re.compile(r'!\[([^\]]+)\]\([^\)]+\)') # ![alt](path/to/image.png)
+PATTERN_REFERENCE_LINK = re.compile(r'\[.+?\]$')  # [Heading][my-id]
+# ![alt](path/to/image.png)
+PATTERN_IMAGE = re.compile(r'!\[([^\]]+)\]\([^\)]+\)')
 PATTERN_EX_ID = re.compile(r'\{#.+?\}$')         # [Heading]{#my-id}
 PATTERN_TAG = re.compile(r'<.*?>')
-PATTERN_ANCHOR = re.compile(r'<a\s+name="[^"]+"\s*>\s*</a>')
-PATTERN_TOC_TAG_SETTING = re.compile(r'\b(?P<name>\w+)=((?P<empty>)|(\'(?P<quoted>[^\']+)\')|("(?P<dquoted>[^"]+)")|(?P<simple>\S+))\s')
+PATTERN_ANCHOR = re.compile(r'<a\s+id="[^"]+"\s*>\s*</a>')
+PATTERN_TOC_TAG_SETTING = re.compile(
+    r'\b(?P<name>\w+)=((?P<empty>)|(\'(?P<quoted>[^\']+)\')|("(?P<dquoted>[^"]+)")|(?P<simple>\S+))\s')
 
 TOCTAG_END = "<!-- /MarkdownTOC -->"
+
 
 class MarkdowntocInsert(sublime_plugin.TextCommand):
 
@@ -108,8 +112,10 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
             codes = []
             for m in re.compile(r'`[^`]*`').finditer(_text):
                 codes.append([m.start(), m.end()])
+
             def not_in_codeblock(target):
                 return not within_ranges(target, codes)
+
             def not_in_image(target):
                 return not within_ranges(target, images)
             # Collect images not in codeblock
@@ -123,9 +129,10 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
             brackets = list(filter(not_in_codeblock, brackets))
             brackets = list(map((lambda x: x[0]), brackets))
             # Escape brackets
+
             def replace_brackets(m):
                 if m.start() in brackets:
-                    return _open+m.group(1)+_close
+                    return _open + m.group(1) + _close
                 else:
                     return m.group(0)
             return re.sub(_pattern, replace_brackets, _text)
@@ -141,8 +148,13 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
         # from MarkdownPreview
         def slugify(value, separator):
             """ Slugify a string, to make it URL friendly. """
-            value = unicodedata.normalize('NFKD', value).encode('ascii', 'ignore')
-            value = re.sub('[^\w\s-]', '', value.decode('ascii')).strip().lower()
+            value = unicodedata.normalize(
+                'NFKD', value).encode(
+                'ascii', 'ignore')
+            value = re.sub(
+                '[^\w\s-]',
+                '',
+                value.decode('ascii')).strip().lower()
             return re.sub('[%s\s]+' % separator, separator, value)
 
         # from MarkdownPreview
@@ -172,11 +184,13 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
                 else:
                     unique[id] += 1
                     id += "-%d" % value
-                return m.group('open')[:-1] + (' id="%s">' % id) + m.group('text') + m.group('close')
+                return m.group('open')[:-1] + (' id="%s">' %
+                                               id) + m.group('text') + m.group('close')
 
             RE_TAGS = re.compile(r'''</?[^>]*>''')
             RE_WORD = re.compile(r'''[^\w\- ]''')
-            RE_HEADER = re.compile(r'''(?P<open><h([1-6])>)(?P<text>.*?)(?P<close></h\2>)''', re.DOTALL)
+            RE_HEADER = re.compile(
+                r'''(?P<open><h([1-6])>)(?P<text>.*?)(?P<close></h\2>)''', re.DOTALL)
 
             return RE_HEADER.sub(inject_id, html)
 
@@ -196,7 +210,8 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
                     _id = heading
                 elif strtobool(attrs['lowercase_only_ascii']):
                     # only ascii
-                    _id = ''.join(chr(ord(x)+('A'<=x<='Z')*32) for x in heading)
+                    _id = ''.join(chr(ord(x) + ('A' <= x <= 'Z') * 32)
+                                  for x in heading)
                 else:
                     _id = heading.lower()
                 return replace_strings_in_id(_id)
@@ -209,7 +224,6 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
                 for _target in _targets:
                     _str = _str.replace(_target, _substitute)
             return _str
-
 
         # Search headings in docment
         pattern_hash = "^#+?[^#]"
@@ -274,6 +288,7 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
                 codes = []
                 for m in re.compile(r'`[^`]*`').finditer(_text):
                     codes.append([m.start(), m.end()])
+
                 def not_in_codeblock(_target):
                     return not within_ranges(_target, codes)
                 # Collect images not in codeblock
@@ -281,6 +296,7 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
                     images.append([m.start(), m.end()])
                 images = list(filter(not_in_codeblock, images))
                 images = list(map((lambda x: x[0]), images))
+
                 def _replace(m):
                     if m.start() in images:
                         return ''
@@ -288,14 +304,16 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
                         return m.group(0)
                 _text = re.sub(PATTERN_IMAGE, _replace, _text)
 
-            _list_bullet = list_bullets[_indent%len(list_bullets)]
-            _text = PATTERN_TAG.sub('', _text) # remove html tags
-            _text = _text.strip() # remove start and end spaces
+            _list_bullet = list_bullets[_indent % len(list_bullets)]
+            _text = PATTERN_TAG.sub('', _text)  # remove html tags
+            _text = _text.strip()  # remove start and end spaces
 
             # Ignore links: e.g. '[link](http://sample.com/)' -> 'link'
-            link = re.compile(r'([^!])\[([^\]]+)\]\([^\)]+\)') # this is [link](http://www.sample.com/)
+            # this is [link](http://www.sample.com/)
+            link = re.compile(r'([^!])\[([^\]]+)\]\([^\)]+\)')
             _text = link.sub('\\1\\2', _text)
-            beginning_link = re.compile(r'^\[([^\]]+)\]\([^\)]+\)') # [link](http://www.sample.com/) link in the beginning of line
+            # [link](http://www.sample.com/) link in the beginning of line
+            beginning_link = re.compile(r'^\[([^\]]+)\]\([^\)]+\)')
             _text = beginning_link.sub('\\1', _text)
 
             # Add indent
@@ -308,16 +326,18 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
             # Reference-style links: e.g. '# heading [my-anchor]'
             list_reference_link = list(PATTERN_REFERENCE_LINK.finditer(_text))
 
-            # Markdown-Extra special attribute style: e.g. '# heading {#my-anchor}'
+            # Markdown-Extra special attribute style: e.g. '# heading
+            # {#my-anchor}'
             match_ex_id = PATTERN_EX_ID.search(_text)
 
             if len(list_reference_link):
                 match = list_reference_link[-1]
-                _text = _text[0:match.start()].replace('[','').replace(']','').rstrip()
-                _id = match.group().replace('[','').replace(']','')
+                _text = _text[0:match.start()].replace(
+                    '[', '').replace(']', '').rstrip()
+                _id = match.group().replace('[', '').replace(']', '')
             elif match_ex_id:
                 _text = _text[0:match_ex_id.start()].rstrip()
-                _id = match_ex_id.group().replace('{#','').replace('}','')
+                _id = match_ex_id.group().replace('{#', '').replace('}', '')
             elif strtobool(attrs['autolink']):
                 _id = heading_to_id(_text)
                 if strtobool(attrs['uri_encoding']):
@@ -326,10 +346,10 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
                 _ids.append(_id)
                 n = _ids.count(_id)
                 if 1 < n:
-                    _id += '-' + str(n-1)
+                    _id += '-' + str(n - 1)
 
             if attrs['style'] == 'unordered':
-                list_prefix = _list_bullet+' '
+                list_prefix = _list_bullet + ' '
             elif attrs['style'] == 'ordered':
                 list_prefix = '1. '
 
@@ -337,9 +357,9 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
             _text = self.escape_brackets(_text)
 
             if link_prefix:
-                _id = link_prefix+_id
+                _id = link_prefix + _id
 
-            if _id == None:
+            if _id is None:
                 toc += list_prefix + _text + '\n'
             elif attrs['bracket'] == 'round':
                 toc += list_prefix + '[' + _text + '](#' + _id + ')\n'
@@ -361,15 +381,20 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
             is_update = PATTERN_ANCHOR.match(v.substr(anchor_region))
             if autoanchor:
                 if is_update:
-                    new_anchor = '<a name="{0}"></a>'.format(item[3])
+                    new_anchor = '<a id="{0}"></a>'.format(item[3])
                     v.replace(edit, anchor_region, new_anchor)
                 else:
-                    new_anchor = '\n<a name="{0}"></a>'.format(item[3])
+                    new_anchor = '\n<a id="{0}"></a>'.format(item[3])
                     v.insert(edit, anchor_region.end(), new_anchor)
 
             else:
                 if is_update:
-                    v.erase(edit, sublime.Region(anchor_region.begin(), anchor_region.end() + 1))
+                    v.erase(
+                        edit,
+                        sublime.Region(
+                            anchor_region.begin(),
+                            anchor_region.end() +
+                            1))
 
     def get_setting(self, attr):
         settings = sublime.load_settings('MarkdownTOC.sublime-settings')
@@ -378,41 +403,45 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
     def get_settings(self):
         """return dict of settings"""
         return {
-            "autoanchor":           self.get_setting('default_autoanchor'),
-            "autolink":             self.get_setting('default_autolink'),
-            "bracket":              self.get_setting('default_bracket'),
-            "depth":                self.get_setting('default_depth'),
-            "remove_image":         self.get_setting('default_remove_image'),
-            "indent":               self.get_setting('default_indent'),
-            "link_prefix":          self.get_setting('default_link_prefix'),
-            "list_bullets":         self.get_setting('default_list_bullets'),
-            "lowercase":            self.get_setting('default_lowercase'),
+            "autoanchor": self.get_setting('default_autoanchor'),
+            "autolink": self.get_setting('default_autolink'),
+            "bracket": self.get_setting('default_bracket'),
+            "depth": self.get_setting('default_depth'),
+            "remove_image": self.get_setting('default_remove_image'),
+            "indent": self.get_setting('default_indent'),
+            "link_prefix": self.get_setting('default_link_prefix'),
+            "list_bullets": self.get_setting('default_list_bullets'),
+            "lowercase": self.get_setting('default_lowercase'),
             "lowercase_only_ascii": self.get_setting('default_lowercase_only_ascii'),
-            "style":                self.get_setting('default_style'),
-            "uri_encoding":         self.get_setting('default_uri_encoding'),
-            "markdown_preview":     self.get_setting('default_markdown_preview')
+            "style": self.get_setting('default_style'),
+            "uri_encoding": self.get_setting('default_uri_encoding'),
+            "markdown_preview": self.get_setting('default_markdown_preview')
         }
 
     def get_attibutes_from(self, tag_str):
         """return dict of settings from tag_str"""
         return dict(
-            (m.group("name"), m.group("simple") or m.group("dquoted") or m.group("quoted") or m.group("empty"))
+            (m.group("name"), m.group("simple") or m.group(
+                "dquoted") or m.group("quoted") or m.group("empty"))
             for m in PATTERN_TOC_TAG_SETTING.finditer(tag_str)
         )
 
     def remove_items_in_codeblock(self, items):
 
         codeblocks = self.view.find_all("^\s*`{3,}[^`]*$")
-        codeblockAreas = [] # [[area_begin, area_end], ..]
+        codeblockAreas = []  # [[area_begin, area_end], ..]
         i = 0
-        while i < len(codeblocks)-1:
+        while i < len(codeblocks) - 1:
             area_begin = codeblocks[i].begin()
-            area_end   = codeblocks[i+1].begin()
+            area_end = codeblocks[i + 1].begin()
             if area_begin and area_end:
                 codeblockAreas.append([area_begin, area_end])
             i += 2
 
-        items = [h for h in items if is_out_of_areas(h.begin(), codeblockAreas)]
+        items = [
+            h for h in items if is_out_of_areas(
+                h.begin(),
+                codeblockAreas)]
         return items
 
     def log(self, arg):
@@ -420,16 +449,19 @@ class MarkdowntocInsert(sublime_plugin.TextCommand):
             arg = str(arg)
             sublime.status_message(arg)
             pp.pprint(arg)
+
     def error(self, arg):
         arg = str(arg)
         sublime.status_message(arg)
         pp.pprint(arg)
+
 
 def is_out_of_areas(num, areas):
     for area in areas:
         if area[0] < num and num < area[1]:
             return False
     return True
+
 
 def format(items):
     headings = []
@@ -438,16 +470,17 @@ def format(items):
     # --------------------------
 
     # minimize diff between headings -----
-    _depths = list(set(headings)) # sort and unique
+    _depths = list(set(headings))  # sort and unique
     # replace with depth rank
     for i, item in enumerate(headings):
-        headings[i] = _depths.index(headings[i])+1
+        headings[i] = _depths.index(headings[i]) + 1
     # ----- /minimize diff between headings
 
     # --------------------------
     for i, item in enumerate(items):
         item[0] = headings[i]
     return items
+
 
 def strtobool(val):
     """pick out from 'distutils.util' module"""
@@ -461,6 +494,7 @@ def strtobool(val):
             raise ValueError("invalid truth value %r" % (val,))
     else:
         return bool(val)
+
 
 def within_ranges(target, ranges):
     tb = target[0]
@@ -486,5 +520,6 @@ class AutoRunner(sublime_plugin.EventListener):
         # limit scope
         root, ext = os.path.splitext(view.file_name())
         ext = ext.lower()
-        if ext in [".md", ".markdown", ".mdown", ".mdwn", ".mkdn", ".mkd", ".mark"]:
+        if ext in [".md", ".markdown", ".mdown",
+                   ".mdwn", ".mkdn", ".mkd", ".mark"]:
             view.run_command('markdowntoc_update')

--- a/tests/autoanchor.py
+++ b/tests/autoanchor.py
@@ -1,7 +1,9 @@
 # coding:utf-8
-from base import TestBase
 import sublime
 import sys
+
+from base import TestBase
+
 
 class TestAutoanchor(TestBase):
     """Test of attributes 'autoanchor'"""
@@ -11,7 +13,7 @@ class TestAutoanchor(TestBase):
     #     pass
 
     autoanchor_text = \
-"""
+        """
 
 <!-- MarkdownTOC autolink=true {0} -->
 
@@ -21,21 +23,27 @@ class TestAutoanchor(TestBase):
 # Glossary
 # API Specification
 """
+
     def test_autoanchor_false(self):
         """Default Auto Anchor is false"""
-        body_txt = self.commonSetupAndUpdateGetBody(self.autoanchor_text.format(''))
-        self.assert_NotIn('<a name="changelog"></a>', body_txt)
-        self.assert_NotIn('<a name="glossary"></a>', body_txt)
-        self.assert_NotIn('<a name="api-specification"></a>', body_txt)
+        body_txt = self.commonSetupAndUpdateGetBody(
+            self.autoanchor_text.format(''))
+        self.assert_NotIn('<a id="changelog"></a>', body_txt)
+        self.assert_NotIn('<a id="glossary"></a>', body_txt)
+        self.assert_NotIn('<a id="api-specification"></a>', body_txt)
 
     def test_autoanchor_true(self):
-        body_txt = self.commonSetupAndUpdateGetBody(self.autoanchor_text.format('autoanchor=true'))
-        self.assert_In('<a name="changelog"></a>\n# Changelog', body_txt)
-        self.assert_In('<a name="glossary"></a>\n# Glossary', body_txt)
-        self.assert_In('<a name="api-specification"></a>\n# API Specification', body_txt)
+        body_txt = self.commonSetupAndUpdateGetBody(
+            self.autoanchor_text.format('autoanchor=true'))
+        self.assert_In('<a id="changelog"></a>\n# Changelog', body_txt)
+        self.assert_In('<a id="glossary"></a>\n# Glossary', body_txt)
+        self.assert_In(
+            '<a id="api-specification"></a>\n# API Specification',
+            body_txt)
 
     def test_autoanchor_false(self):
-        body_txt = self.commonSetupAndUpdateGetBody(self.autoanchor_text.format('autoanchor=false'))
-        self.assert_NotIn('<a name="changelog"></a>', body_txt)
-        self.assert_NotIn('<a name="glossary"></a>', body_txt)
-        self.assert_NotIn('<a name="api-specification"></a>', body_txt)
+        body_txt = self.commonSetupAndUpdateGetBody(
+            self.autoanchor_text.format('autoanchor=false'))
+        self.assert_NotIn('<a id="changelog"></a>', body_txt)
+        self.assert_NotIn('<a id="glossary"></a>', body_txt)
+        self.assert_NotIn('<a id="api-specification"></a>', body_txt)


### PR DESCRIPTION
### 1. Summary

I replace `name` attribute to `id`.

### 2. Argumentation

Name attribute [**is obsolete**](https://www.w3schools.com/tags/att_a_name.asp), so my site is not valid. See **#115** for details.

### 3. Behavior before pull request

If `"default_autoanchor": true,` in settings:

```markdown
<a name="sashaheader"></a>
# Relevance
```

### 4. Behavior after pull request

```markdown
<a id="sashaheader"></a>
# Relevance
```

Site successful works, if I replace `name` to `id`.

### 5. Tests

I open `autoanchor.py` → `UnitTesting: Test Current File`:

```markdown
test_autoanchor_false (autoanchor.TestAutoanchor) … ok
test_autoanchor_true (autoanchor.TestAutoanchor) … ok

----------------------------------------------------------------------
Ran 2 tests in 0.206s

OK

UnitTesting: Done.
```

### 6. Testing environment

+ Windows 10 Enterprise LTSB 64-bit EN,
+ Sublime Text Build 3143,
+ MarkdownTOC 2018.01.13.09.31.42
+ UnitTesting 1.2.0,

### 7. Note

I don't find in your [**contributing guidelines**](https://github.com/naokazuterada/MarkdownTOC/blob/master/.github/CONTRIBUTING.md) your preferred coding style. Possibly, MarkdownTOC haven't good code quality:

<details>
<summary>
<b>Click here to see full report.</b></summary><br>

```batch
D:\Sublime Text 3 x64\Data\Packages\MarkdownTOC>flake8 .
.\MarkdownTOC.py:6:1: F401 'sys' imported but unused
.\MarkdownTOC.py:21:80: E501 line too long (103 > 79 characters)
.\MarkdownTOC.py:93:21: N806 variable 'tocRegion' in function should be lowercase
.\MarkdownTOC.py:188:80: E501 line too long (87 > 79 characters)
.\MarkdownTOC.py:190:13: N806 variable 'RE_TAGS' in function should be lowercase
.\MarkdownTOC.py:191:13: N806 variable 'RE_WORD' in function should be lowercase
.\MarkdownTOC.py:192:13: N806 variable 'RE_HEADER' in function should be lowercase
.\MarkdownTOC.py:193:80: E501 line too long (85 > 79 characters)
.\MarkdownTOC.py:276:9: F841 local variable 'level_counters' is assigned to but never used
.\MarkdownTOC.py:376:80: E501 line too long (87 > 79 characters)
.\MarkdownTOC.py:415:80: E501 line too long (85 > 79 characters)
.\MarkdownTOC.py:432:9: N806 variable 'codeblockAreas' in function should be lowercase
.\MarkdownTOC.py:448:40: E712 comparison to True should be 'if cond is True:' or 'if cond:'
.\MarkdownTOC.py:501:5: F841 local variable 'te' is assigned to but never used
.\tests\autoanchor.py:2:1: F401 'sublime' imported but unused
.\tests\autoanchor.py:3:1: F401 'sys' imported but unused
.\tests\autoanchor.py:44:5: F811 redefinition of unused 'test_autoanchor_false' from line 27
.\tests\autolink.py:3:1: F401 'sublime' imported but unused
.\tests\autolink.py:4:1: F401 'sys' imported but unused
.\tests\autolink.py:6:1: E302 expected 2 blank lines, found 1
.\tests\autolink.py:14:1: E128 continuation line under-indented for visual indent
.\tests\base.py:2:1: F401 'os' imported but unused
.\tests\base.py:4:1: F401 'sys' imported but unused
.\tests\base.py:12:80: E501 line too long (99 > 79 characters)
.\tests\base.py:29:9: N802 function name 'setText' should be lowercase xxx
.\tests\base.py:32:9: N802 function name 'getRow' should be lowercase xxx
.\tests\base.py:35:9: N802 function name 'moveTo' should be lowercase xxx
.\tests\base.py:40:9: N802 function name 'getTOC_text' should be lowercase xxx
.\tests\base.py:54:9: N802 function name 'commonSetup' should be lowercase xxx
.\tests\base.py:59:80: E501 line too long (89 > 79 characters)
.\tests\base.py:73:9: N802 function name 'commonSetupAndUpdate' should be lowercase xxx
.\tests\base.py:83:9: N802 function name 'commonSetupAndUpdateGetBody' should be lowercase xxx
.\tests\base.py:95:9: N802 function name 'assert_NotIn' should be lowercase xxx
.\tests\base.py:102:9: N802 function name 'assert_In' should be lowercase xxx
.\tests\bracket.py:3:1: F401 'sublime' imported but unused
.\tests\bracket.py:4:1: F401 'sys' imported but unused
.\tests\bracket.py:6:1: E302 expected 2 blank lines, found 1
.\tests\bracket.py:16:1: E128 continuation line under-indented for visual indent
.\tests\bracket.py:24:5: E301 expected 1 blank line, found 0
.\tests\default.py:4:1: E302 expected 2 blank lines, found 1
.\tests\default.py:12:1: E128 continuation line under-indented for visual indent
.\tests\default.py:36:5: E301 expected 1 blank line, found 0
.\tests\default.py:36:9: N802 function name 'test_before_than_TOC_should_be_ignored' should be lowercase xxx
.\tests\default.py:40:9: N802 function name 'test_after_than_TOC_should_be_included' should be lowercase xxx
.\tests\default.py:49:1: E122 continuation line missing indentation or outdented
.\tests\default.py:76:1: E122 continuation line missing indentation or outdented
.\tests\default.py:89:1: E128 continuation line under-indented for visual indent
.\tests\default.py:99:1: E122 continuation line missing indentation or outdented
.\tests\default.py:113:1: E128 continuation line under-indented for visual indent
.\tests\default.py:135:1: E128 continuation line under-indented for visual indent
.\tests\default.py:162:5: E303 too many blank lines (2)
.\tests\default.py:165:1: E128 continuation line under-indented for visual indent
.\tests\default.py:178:80: E501 line too long (99 > 79 characters)
.\tests\default.py:180:80: E501 line too long (91 > 79 characters)
.\tests\default.py:185:1: E128 continuation line under-indented for visual indent
.\tests\default.py:197:80: E501 line too long (92 > 79 characters)
.\tests\default.py:198:80: E501 line too long (145 > 79 characters)
.\tests\default.py:199:80: E501 line too long (108 > 79 characters)
.\tests\default.py:200:80: E501 line too long (134 > 79 characters)
.\tests\default.py:205:1: E128 continuation line under-indented for visual indent
.\tests\default.py:222:1: E128 continuation line under-indented for visual indent
.\tests\default.py:237:5: F811 redefinition of unused 'test_uniquify_id' from line 219
.\tests\default.py:240:1: E128 continuation line under-indented for visual indent
.\tests\default.py:259:1: E128 continuation line under-indented for visual indent
.\tests\default.py:277:1: E128 continuation line under-indented for visual indent
.\tests\depth.py:3:1: F401 'sublime' imported but unused
.\tests\depth.py:4:1: F401 'sys' imported but unused
.\tests\depth.py:6:1: E302 expected 2 blank lines, found 1
.\tests\depth.py:14:1: E128 continuation line under-indented for visual indent
.\tests\depth.py:26:5: E301 expected 1 blank line, found 0
.\tests\indent.py:3:1: F401 'sublime' imported but unused
.\tests\indent.py:4:1: F401 'sys' imported but unused
.\tests\indent.py:6:1: E302 expected 2 blank lines, found 1
.\tests\indent.py:14:1: E128 continuation line under-indented for visual indent
.\tests\indent.py:25:80: E501 line too long (98 > 79 characters)
.\tests\indent.py:35:80: E501 line too long (82 > 79 characters)
.\tests\indent.py:42:80: E501 line too long (84 > 79 characters)
.\tests\link_prefix.py:3:1: F401 'sublime' imported but unused
.\tests\link_prefix.py:4:1: F401 'sys' imported but unused
.\tests\link_prefix.py:6:1: E302 expected 2 blank lines, found 1
.\tests\link_prefix.py:14:1: E128 continuation line under-indented for visual indent
.\tests\link_prefix.py:22:5: E301 expected 1 blank line, found 0
.\tests\link_prefix.py:24:80: E501 line too long (83 > 79 characters)
.\tests\link_prefix.py:25:5: E301 expected 1 blank line, found 0
.\tests\link_prefix.py:26:80: E501 line too long (95 > 79 characters)
.\tests\link_prefix.py:27:80: E501 line too long (96 > 79 characters)
.\tests\list_bullets.py:3:1: F401 'sublime' imported but unused
.\tests\list_bullets.py:4:1: F401 'sys' imported but unused
.\tests\list_bullets.py:6:1: E302 expected 2 blank lines, found 1
.\tests\list_bullets.py:14:1: E128 continuation line under-indented for visual indent
.\tests\list_bullets.py:30:5: E301 expected 1 blank line, found 0
.\tests\list_bullets.py:41:5: E301 expected 1 blank line, found 0
.\tests\list_bullets.py:42:80: E501 line too long (86 > 79 characters)
.\tests\list_bullets.py:52:5: E301 expected 1 blank line, found 0
.\tests\list_bullets.py:53:80: E501 line too long (87 > 79 characters)
.\tests\list_bullets.py:63:5: E301 expected 1 blank line, found 0
.\tests\list_bullets.py:64:80: E501 line too long (88 > 79 characters)
.\tests\list_bullets.py:73:46: W292 no newline at end of file
.\tests\lowercase.py:3:1: F401 'sublime' imported but unused
.\tests\lowercase.py:4:1: F401 'sys' imported but unused
.\tests\lowercase.py:6:1: E302 expected 2 blank lines, found 1
.\tests\lowercase.py:14:1: E128 continuation line under-indented for visual indent
.\tests\lowercase.py:16:80: E501 line too long (83 > 79 characters)
.\tests\lowercase.py:24:5: E301 expected 1 blank line, found 0
.\tests\lowercase.py:29:80: E501 line too long (82 > 79 characters)
.\tests\lowercase.py:33:80: E501 line too long (96 > 79 characters)
.\tests\lowercase.py:37:80: E501 line too long (97 > 79 characters)
.\tests\lowercase.py:42:1: E128 continuation line under-indented for visual indent
.\tests\lowercase.py:44:80: E501 line too long (84 > 79 characters)
.\tests\lowercase.py:52:5: E301 expected 1 blank line, found 0
.\tests\lowercase.py:57:80: E501 line too long (83 > 79 characters)
.\tests\lowercase.py:61:80: E501 line too long (97 > 79 characters)
.\tests\lowercase.py:65:80: E501 line too long (98 > 79 characters)
.\tests\lowercase_only_ascii.py:3:1: F401 'sublime' imported but unused
.\tests\lowercase_only_ascii.py:4:1: F401 'sys' imported but unused
.\tests\lowercase_only_ascii.py:6:1: E302 expected 2 blank lines, found 1
.\tests\lowercase_only_ascii.py:14:1: E128 continuation line under-indented for visual indent
.\tests\lowercase_only_ascii.py:22:5: E301 expected 1 blank line, found 0
.\tests\lowercase_only_ascii.py:27:80: E501 line too long (102 > 79 characters)
.\tests\lowercase_only_ascii.py:31:80: E501 line too long (103 > 79 characters)
.\tests\markdown_preview.py:3:1: F401 'sublime' imported but unused
.\tests\markdown_preview.py:4:1: F401 'sys' imported but unused
.\tests\markdown_preview.py:6:1: E302 expected 2 blank lines, found 1
.\tests\markdown_preview.py:14:1: E128 continuation line under-indented for visual indent
.\tests\markdown_preview.py:47:80: E501 line too long (98 > 79 characters)
.\tests\markdown_preview.py:58:80: E501 line too long (96 > 79 characters)
.\tests\markdown_preview.py:59:80: E501 line too long (85 > 79 characters)
.\tests\markdown_preview.py:61:80: E501 line too long (80 > 79 characters)
.\tests\markdown_preview.py:64:80: E501 line too long (99 > 79 characters)
.\tests\markdown_preview.py:65:80: E501 line too long (101 > 79 characters)
.\tests\markdown_preview.py:69:80: E501 line too long (101 > 79 characters)
.\tests\markdown_preview.py:74:1: E128 continuation line under-indented for visual indent
.\tests\markdown_preview.py:84:5: E301 expected 1 blank line, found 0
.\tests\markdown_preview.py:85:80: E501 line too long (110 > 79 characters)
.\tests\markdown_preview.py:89:5: E301 expected 1 blank line, found 0
.\tests\markdown_preview.py:90:80: E501 line too long (108 > 79 characters)
.\tests\markdown_preview.py:97:1: E128 continuation line under-indented for visual indent
.\tests\markdown_preview.py:104:5: E301 expected 1 blank line, found 0
.\tests\markdown_preview.py:105:80: E501 line too long (109 > 79 characters)
.\tests\markdown_preview.py:107:5: E301 expected 1 blank line, found 0
.\tests\markdown_preview.py:108:80: E501 line too long (107 > 79 characters)
.\tests\markdown_preview.py:109:42: W292 no newline at end of file
.\tests\remove_image.py:3:1: F401 'sublime' imported but unused
.\tests\remove_image.py:4:1: F401 'sys' imported but unused
.\tests\remove_image.py:6:1: E302 expected 2 blank lines, found 1
.\tests\remove_image.py:14:1: E128 continuation line under-indented for visual indent
.\tests\remove_image.py:27:5: E301 expected 1 blank line, found 0
.\tests\remove_image.py:34:5: E301 expected 1 blank line, found 0
.\tests\remove_image.py:37:5: E301 expected 1 blank line, found 0
.\tests\remove_image.py:38:80: E501 line too long (88 > 79 characters)
.\tests\remove_image.py:40:5: E301 expected 1 blank line, found 0
.\tests\remove_image.py:41:80: E501 line too long (89 > 79 characters)
.\tests\remove_image.py:50:1: E128 continuation line under-indented for visual indent
.\tests\remove_image.py:57:80: E501 line too long (82 > 79 characters)
.\tests\remove_image.py:59:80: E501 line too long (84 > 79 characters)
.\tests\remove_image.py:60:80: E501 line too long (85 > 79 characters)
.\tests\remove_image.py:61:80: E501 line too long (90 > 79 characters)
.\tests\remove_image.py:72:5: E301 expected 1 blank line, found 0
.\tests\remove_image.py:74:80: E501 line too long (80 > 79 characters)
.\tests\remove_image.py:75:80: E501 line too long (92 > 79 characters)
.\tests\remove_image.py:76:80: E501 line too long (97 > 79 characters)
.\tests\remove_image.py:77:80: E501 line too long (98 > 79 characters)
.\tests\remove_image.py:78:80: E501 line too long (103 > 79 characters)
.\tests\remove_image.py:88:5: E301 expected 1 blank line, found 0
.\tests\remove_image.py:91:5: E301 expected 1 blank line, found 0
.\tests\remove_image.py:92:80: E501 line too long (98 > 79 characters)
.\tests\remove_image.py:94:5: E301 expected 1 blank line, found 0
.\tests\remove_image.py:95:80: E501 line too long (99 > 79 characters)
.\tests\remove_image.py:96:80: E501 line too long (94 > 79 characters)
.\tests\remove_image.py:97:80: E501 line too long (99 > 79 characters)
.\tests\remove_image.py:98:80: E501 line too long (92 > 79 characters)
.\tests\remove_image.py:99:80: E501 line too long (97 > 79 characters)
.\tests\remove_image.py:100:80: E501 line too long (98 > 79 characters)
.\tests\remove_image.py:101:80: E501 line too long (103 > 79 characters)
.\tests\remove_image.py:110:67: W292 no newline at end of file
.\tests\style.py:3:1: F401 'sublime' imported but unused
.\tests\style.py:4:1: F401 'sys' imported but unused
.\tests\style.py:6:1: E302 expected 2 blank lines, found 1
.\tests\style.py:14:1: E128 continuation line under-indented for visual indent
.\tests\style.py:25:5: E301 expected 1 blank line, found 0
.\tests\uri_encoding.py:3:1: F401 'sublime' imported but unused
.\tests\uri_encoding.py:4:1: F401 'sys' imported but unused
.\tests\uri_encoding.py:6:1: E302 expected 2 blank lines, found 1
.\tests\uri_encoding.py:14:1: E128 continuation line under-indented for visual indent
.\tests\uri_encoding.py:27:5: E301 expected 1 blank line, found 0
.\tests\uri_encoding.py:31:80: E501 line too long (113 > 79 characters)
.\tests\uri_encoding.py:32:80: E501 line too long (99 > 79 characters)
.\tests\uri_encoding.py:33:80: E501 line too long (81 > 79 characters)
.\tests\uri_encoding.py:36:80: E501 line too long (86 > 79 characters)
.\tests\uri_encoding.py:39:80: E501 line too long (113 > 79 characters)
.\tests\uri_encoding.py:40:80: E501 line too long (99 > 79 characters)
.\tests\uri_encoding.py:41:80: E501 line too long (81 > 79 characters)
.\tests\uri_encoding.py:44:80: E501 line too long (87 > 79 characters)

D:\Sublime Text 3 x64\Data\Packages\MarkdownTOC>vulture MarkdownTOC.py
MarkdownTOC.py:6: unused import 'sys' (90% confidence)
MarkdownTOC.py:28: unused function 'run' (60% confidence)
MarkdownTOC.py:276: unused variable 'level_counters' (60% confidence)
MarkdownTOC.py:453: unused function 'error' (60% confidence)
MarkdownTOC.py:501: unused variable 'te' (60% confidence)
MarkdownTOC.py:511: unused class 'MarkdowntocUpdate' (60% confidence)
MarkdownTOC.py:513: unused function 'run' (60% confidence)
MarkdownTOC.py:517: unused class 'AutoRunner' (60% confidence)
MarkdownTOC.py:519: unused function 'on_pre_save' (60% confidence)
MarkdownTOC.py:521: unused variable 'root' (60% confidence)

D:\Sublime Text 3 x64\Data\Packages\MarkdownTOC>pydocstyle
.\MarkdownTOC.py:1 at module level:
        D100: Missing docstring in public module
.\MarkdownTOC.py:26 in public class `MarkdowntocInsert`:
        D101: Missing docstring in public class
.\MarkdownTOC.py:28 in public method `run`:
        D102: Missing docstring in public method
.\MarkdownTOC.py:47 in public method `get_toc_open_tag`:
        D102: Missing docstring in public method
.\MarkdownTOC.py:74 in public method `get_toc_close_tag`:
        D102: Missing docstring in public method
.\MarkdownTOC.py:81 in public method `find_tag_and_insert`:
        D400: First line should end with a period (not 't')
.\MarkdownTOC.py:106 in public method `escape_brackets`:
        D102: Missing docstring in public method
.\MarkdownTOC.py:146 in public method `get_toc`:
        D102: Missing docstring in public method
.\MarkdownTOC.py:149 in private nested function `slugify`:
        D210: No whitespaces allowed surrounding docstring text
.\MarkdownTOC.py:161 in private nested function `postprocess_inject_header_id`:
        D210: No whitespaces allowed surrounding docstring text
.\MarkdownTOC.py:161 in private nested function `postprocess_inject_header_id`:
        D400: First line should end with a period (not 't')
.\MarkdownTOC.py:399 in public method `get_setting`:
        D102: Missing docstring in public method
.\MarkdownTOC.py:403 in public method `get_settings`:
        D400: First line should end with a period (not 's')
.\MarkdownTOC.py:403 in public method `get_settings`:
        D403: First word of the first line should be properly capitalized ('Return', not 'return')
.\MarkdownTOC.py:421 in public method `get_attibutes_from`:
        D400: First line should end with a period (not 'r')
.\MarkdownTOC.py:421 in public method `get_attibutes_from`:
        D403: First word of the first line should be properly capitalized ('Return', not 'return')
.\MarkdownTOC.py:429 in public method `remove_items_in_codeblock`:
        D102: Missing docstring in public method
.\MarkdownTOC.py:447 in public method `log`:
        D102: Missing docstring in public method
.\MarkdownTOC.py:453 in public method `error`:
        D102: Missing docstring in public method
.\MarkdownTOC.py:459 in public function `is_out_of_areas`:
        D103: Missing docstring in public function
.\MarkdownTOC.py:466 in public function `format`:
        D103: Missing docstring in public function
.\MarkdownTOC.py:485 in public function `strtobool`:
        D400: First line should end with a period (not 'e')
.\MarkdownTOC.py:485 in public function `strtobool`:
        D403: First word of the first line should be properly capitalized ('Pick', not 'pick')
.\MarkdownTOC.py:499 in public function `within_ranges`:
        D103: Missing docstring in public function
.\MarkdownTOC.py:511 in public class `MarkdowntocUpdate`:
        D101: Missing docstring in public class
.\MarkdownTOC.py:513 in public method `run`:
        D102: Missing docstring in public method
.\MarkdownTOC.py:517 in public class `AutoRunner`:
        D101: Missing docstring in public class
.\MarkdownTOC.py:519 in public method `on_pre_save`:
        D102: Missing docstring in public method
.\tests\autoanchor.py:1 at module level:
        D100: Missing docstring in public module
.\tests\autoanchor.py:8 in public class `TestAutoanchor`:
        D400: First line should end with a period (not "'")
.\tests\autoanchor.py:27 in public method `test_autoanchor_false`:
        D400: First line should end with a period (not 'e')
.\tests\autoanchor.py:35 in public method `test_autoanchor_true`:
        D102: Missing docstring in public method
.\tests\autoanchor.py:44 in public method `test_autoanchor_false`:
        D102: Missing docstring in public method
.\tests\autolink.py:1 at module level:
        D100: Missing docstring in public module
.\tests\autolink.py:6 in public class `TestAutolink`:
        D400: First line should end with a period (not "'")
.\tests\autolink.py:23 in public method `test_autolink_default`:
        D400: First line should end with a period (not 'e')
.\tests\autolink.py:28 in public method `test_autolink_true`:
        D102: Missing docstring in public method
.\tests\autolink.py:32 in public method `test_autolink_false`:
        D102: Missing docstring in public method
.\tests\base.py:1 at module level:
        D100: Missing docstring in public module
.\tests\base.py:14 in public method `setUp`:
        D102: Missing docstring in public method
.\tests\base.py:20 in public method `tearDown`:
        D102: Missing docstring in public method
.\tests\base.py:29 in public method `setText`:
        D102: Missing docstring in public method
.\tests\base.py:32 in public method `getRow`:
        D102: Missing docstring in public method
.\tests\base.py:54 in public method `commonSetup`:
        D102: Missing docstring in public method
.\tests\base.py:73 in public method `commonSetupAndUpdate`:
        D102: Missing docstring in public method
.\tests\base.py:83 in public method `commonSetupAndUpdateGetBody`:
        D102: Missing docstring in public method
.\tests\bracket.py:1 at module level:
        D100: Missing docstring in public module
.\tests\bracket.py:6 in public class `TestBracket`:
        D400: First line should end with a period (not "'")
.\tests\bracket.py:24 in public method `test_bracket_default`:
        D400: First line should end with a period (not 'e')
.\tests\bracket.py:29 in public method `test_bracket_square`:
        D102: Missing docstring in public method
.\tests\bracket.py:33 in public method `test_bracket_round`:
        D102: Missing docstring in public method
.\tests\default.py:1 at module level:
        D100: Missing docstring in public module
.\tests\default.py:4 in public class `TestDefault`:
        D400: First line should end with a period (not 's')
.\tests\default.py:36 in public method `test_before_than_TOC_should_be_ignored`:
        D102: Missing docstring in public method
.\tests\default.py:40 in public method `test_after_than_TOC_should_be_included`:
        D102: Missing docstring in public method
.\tests\default.py:47 in public method `test_ignore_inside_codeblock`:
        D102: Missing docstring in public method
.\tests\default.py:74 in public method `test_escape_link`:
        D102: Missing docstring in public method
.\tests\default.py:84 in public method `test_escape_brackets`:
        D205: 1 blank line required between summary line and description (found 0)
.\tests\default.py:84 in public method `test_escape_brackets`:
        D400: First line should end with a period (not 's')
.\tests\default.py:97 in public method `test_spaces_in_atx_heading`:
        D102: Missing docstring in public method
.\tests\default.py:110 in public method `test_remove_atx_closing_seq`:
        D210: No whitespaces allowed surrounding docstring text
.\tests\default.py:110 in public method `test_remove_atx_closing_seq`:
        D400: First line should end with a period (not 's')
.\tests\default.py:132 in public method `test_id_replacement`:
        D210: No whitespaces allowed surrounding docstring text
.\tests\default.py:132 in public method `test_id_replacement`:
        D400: First line should end with a period (not 'g')
.\tests\default.py:162 in public method `test_no_escape_in_code`:
        D210: No whitespaces allowed surrounding docstring text
.\tests\default.py:162 in public method `test_no_escape_in_code`:
        D400: First line should end with a period (not 'k')
.\tests\default.py:182 in public method `test_no_escape_in_code_with_link`:
        D210: No whitespaces allowed surrounding docstring text
.\tests\default.py:182 in public method `test_no_escape_in_code_with_link`:
        D400: First line should end with a period (not ')')
.\tests\default.py:202 in public method `test_no_headings`:
        D210: No whitespaces allowed surrounding docstring text
.\tests\default.py:202 in public method `test_no_headings`:
        D400: First line should end with a period (not 'e')
.\tests\default.py:219 in public method `test_uniquify_id`:
        D210: No whitespaces allowed surrounding docstring text
.\tests\default.py:219 in public method `test_uniquify_id`:
        D400: First line should end with a period (not 's')
.\tests\default.py:219 in public method `test_uniquify_id`:
        D403: First word of the first line should be properly capitalized ('Uniquify', not 'uniquify')
.\tests\default.py:237 in public method `test_uniquify_id`:
        D210: No whitespaces allowed surrounding docstring text
.\tests\default.py:237 in public method `test_uniquify_id`:
        D400: First line should end with a period (not 's')
.\tests\default.py:237 in public method `test_uniquify_id`:
        D403: First word of the first line should be properly capitalized ('Handle', not 'handle')
.\tests\default.py:256 in public method `test_whitespace_in_begining`:
        D400: First line should end with a period (not 'g')
.\tests\default.py:274 in public method `test_image_in_heading`:
        D400: First line should end with a period (not 'g')
.\tests\depth.py:1 at module level:
        D100: Missing docstring in public module
.\tests\depth.py:6 in public class `TestDepth`:
        D400: First line should end with a period (not "'")
.\tests\depth.py:26 in public method `test_depth_default`:
        D400: First line should end with a period (not '2')
.\tests\depth.py:35 in public method `test_depth_0`:
        D400: First line should end with a period (not 't')
.\tests\depth.py:44 in public method `test_depth_1`:
        D102: Missing docstring in public method
.\tests\depth.py:52 in public method `test_depth_2`:
        D102: Missing docstring in public method
.\tests\depth.py:60 in public method `test_depth_3`:
        D102: Missing docstring in public method
.\tests\depth.py:68 in public method `test_depth_4`:
        D102: Missing docstring in public method
.\tests\depth.py:76 in public method `test_depth_5`:
        D102: Missing docstring in public method
.\tests\indent.py:1 at module level:
        D100: Missing docstring in public module
.\tests\indent.py:6 in public class `TestIndent`:
        D400: First line should end with a period (not "'")
.\tests\indent.py:34 in public method `test_indent_2spaces`:
        D102: Missing docstring in public method
.\tests\indent.py:41 in public method `test_indent_4spaces`:
        D102: Missing docstring in public method
.\tests\link_prefix.py:1 at module level:
        D100: Missing docstring in public module
.\tests\link_prefix.py:6 in public class `LinkPrefixBullets`:
        D400: First line should end with a period (not "'")
.\tests\link_prefix.py:22 in public method `test_link_prefix_default`:
        D102: Missing docstring in public method
.\tests\link_prefix.py:25 in public method `test_link_prefix_1`:
        D102: Missing docstring in public method
.\tests\list_bullets.py:1 at module level:
        D100: Missing docstring in public module
.\tests\list_bullets.py:6 in public class `TestListBullets`:
        D400: First line should end with a period (not "'")
.\tests\list_bullets.py:30 in public method `test_list_bullets_default`:
        D102: Missing docstring in public method
.\tests\list_bullets.py:41 in public method `test_list_bullets_2values`:
        D102: Missing docstring in public method
.\tests\list_bullets.py:52 in public method `test_list_bullets_3values`:
        D102: Missing docstring in public method
.\tests\list_bullets.py:63 in public method `test_list_bullets_4values`:
        D102: Missing docstring in public method
.\tests\lowercase.py:1 at module level:
        D100: Missing docstring in public module
.\tests\lowercase.py:6 in public class `TestLowercase`:
        D400: First line should end with a period (not "'")
.\tests\lowercase.py:24 in public method `common_only_ascii_true`:
        D102: Missing docstring in public method
.\tests\lowercase.py:28 in public method `test_lowercase_default_only_ascii_true`:
        D102: Missing docstring in public method
.\tests\lowercase.py:32 in public method `test_lowercase_true_only_ascii_true`:
        D102: Missing docstring in public method
.\tests\lowercase.py:36 in public method `test_lowercase_false_only_ascii_true`:
        D102: Missing docstring in public method
.\tests\lowercase.py:52 in public method `common_only_ascii_false`:
        D102: Missing docstring in public method
.\tests\lowercase.py:56 in public method `test_lowercase_default_only_ascii_false`:
        D102: Missing docstring in public method
.\tests\lowercase.py:60 in public method `test_lowercase_true_only_ascii_false`:
        D102: Missing docstring in public method
.\tests\lowercase.py:64 in public method `test_lowercase_false_only_ascii_false`:
        D102: Missing docstring in public method
.\tests\lowercase_only_ascii.py:1 at module level:
        D100: Missing docstring in public module
.\tests\lowercase_only_ascii.py:6 in public class `TestLowercaseOnlyAscii`:
        D400: First line should end with a period (not "'")
.\tests\lowercase_only_ascii.py:22 in public method `test_lowercase_only_ascii_default`:
        D102: Missing docstring in public method
.\tests\lowercase_only_ascii.py:26 in public method `test_lowercase_only_ascii_true`:
        D102: Missing docstring in public method
.\tests\lowercase_only_ascii.py:30 in public method `test_lowercase_only_ascii_false`:
        D102: Missing docstring in public method
.\tests\markdown_preview.py:1 at module level:
        D100: Missing docstring in public module
.\tests\markdown_preview.py:6 in public class `TestMarkdownPreview`:
        D400: First line should end with a period (not "'")
.\tests\markdown_preview.py:31 in public method `common_markdown_preview`:
        D102: Missing docstring in public method
.\tests\markdown_preview.py:41 in public method `test_markdown_preview_default`:
        D102: Missing docstring in public method
.\tests\markdown_preview.py:46 in public method `test_markdown_preview_markdown`:
        D102: Missing docstring in public method
.\tests\markdown_preview.py:57 in public method `test_markdown_preview_github`:
        D102: Missing docstring in public method
.\tests\markdown_preview.py:68 in public method `test_markdown_preview_othervalues`:
        D102: Missing docstring in public method
.\tests\markdown_preview.py:84 in public method `test_markdown_preview_uniquify_id_markdown`:
        D102: Missing docstring in public method
.\tests\markdown_preview.py:89 in public method `test_markdown_preview_uniquify_id_github`:
        D102: Missing docstring in public method
.\tests\markdown_preview.py:104 in public method `test_markdown_preview_no_heading_markdown`:
        D102: Missing docstring in public method
.\tests\markdown_preview.py:107 in public method `test_markdown_preview_no_heading_github`:
        D102: Missing docstring in public method
.\tests\remove_image.py:1 at module level:
        D100: Missing docstring in public module
.\tests\remove_image.py:6 in public class `TestRemoveImage`:
        D400: First line should end with a period (not "'")
.\tests\remove_image.py:27 in public method `common_remove_image_default`:
        D102: Missing docstring in public method
.\tests\remove_image.py:34 in public method `test_remove_image_default`:
        D102: Missing docstring in public method
.\tests\remove_image.py:37 in public method `test_remove_image_true`:
        D102: Missing docstring in public method
.\tests\remove_image.py:40 in public method `test_remove_image_false`:
        D102: Missing docstring in public method
.\tests\remove_image.py:72 in public method `common_remove_image_codeblock_default`:
        D102: Missing docstring in public method
.\tests\remove_image.py:88 in public method `test_remove_image_codeblock_default`:
        D102: Missing docstring in public method
.\tests\remove_image.py:91 in public method `test_remove_image_codeblock_true`:
        D102: Missing docstring in public method
.\tests\remove_image.py:94 in public method `test_remove_image_codeblock_false`:
        D102: Missing docstring in public method
.\tests\style.py:1 at module level:
        D100: Missing docstring in public module
.\tests\style.py:6 in public class `TestStyle`:
        D400: First line should end with a period (not "'")
.\tests\style.py:25 in public method `test_style_default`:
        D400: First line should end with a period (not 'd')
.\tests\style.py:33 in public method `test_style_ordered`:
        D102: Missing docstring in public method
.\tests\style.py:40 in public method `test_style_unordered`:
        D102: Missing docstring in public method
.\tests\uri_encoding.py:1 at module level:
        D100: Missing docstring in public module
.\tests\uri_encoding.py:6 in public class `TestUriEncoding`:
        D400: First line should end with a period (not "'")
.\tests\uri_encoding.py:27 in public method `test_uri_encoding_default`:
        D102: Missing docstring in public method
.\tests\uri_encoding.py:35 in public method `test_uri_encoding_true`:
        D102: Missing docstring in public method
.\tests\uri_encoding.py:43 in public method `test_uri_encoding_false`:
        D102: Missing docstring in public method

D:\Sublime Text 3 x64\Data\Packages\MarkdownTOC>
```
</details><br>

my IDE [**Anaconda**](https://damnwidget.github.io/anaconda/) automatically fix some your code to [**PEP8 guidelines**](https://www.python.org/dev/peps/pep-0008/).

Thanks.