### PR TITLE
Added tip on using MarkdownTOC in conjunction with Markdownlint (Node)

### DIFF
--- a/README.md
+++ b/README.md
@@ -781,6 +781,30 @@ And when **Jekyll** is done, your headings should render correctly.
 
 Ref: [Github issue #81](https://github.com/naokazuterada/MarkdownTOC/issues/81)
 
+### Using MarkdownTOC with Markdownlint
+
+If you are using [Markdownlint](https://github.com/DavidAnson/markdownlint) (Node implementation), it will report several violations out of the box.
+
+The basic configuration you can use to address these looks like the following:
+
+```json
+{
+    "html": false,
+    "blanks-around-headings": false,
+    "ul-indent": {
+        "indent": 4
+    }
+}
+```
+
+- `html` set to `false`, to allow use of HTML since **MarkdownTOC** relies on HTML tags to assist the Markdown
+- `blanks-around-headings` should be set to `false`, since anchors are places closed to the headings that are listed in the TOC
+- `ul-indent` should have it's parameter `indent` set to `4` to adhere with the default of `4` used by **MarkdownTOC**, whereas **Markdownlint** defaults to `2`
+
+If you have configured **MarkdownTOC** differently, you can adjust your **Markdownlint** configuration accordingly.
+
+Do note that this tip is based on the **Node** implementation, [available on GitHub](https://github.com/DavidAnson/markdownlint), which uses a project specific `.markdownlint.json` based configuration.
+
 ## Limitations
 
 **MarkdownTOC** does come with some limitations.


### PR DESCRIPTION
Hi @naokazuterada 

I have added a tip to the documentation on how to configure **Markdownlint** (Node implementation), in conjunction with **MarkdownTOC**.

It provides a basic configuration dealing with violations of the best practices suggested by **Markdownlint** out of the box and get the two to play well together with a little configuration to **Markdownlint**.

I am pondering doing a tip on how to configure **MarkdownTOC** to adhere to the **Markdownlint** recommendations, so you can use either tip depending on your preferences.