### PR TITLE
Fixing failing Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ matrix:
     include:
         - os: linux
           language: python
-          python: 3.3
+          python: 3.7
         - os: osx
           language: generic
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,6 +10,7 @@ env:
 matrix:
     include:
         - os: linux
+          services: xvfb
           language: python
           python: 3.7
         - os: osx

--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ before_install:
     - if [ "$TRAVIS_OS_NAME" == "linux"  ]; then
             export DISPLAY=:99.0;
             sh -e /etc/init.d/xvfb start;
+            sleep 3;
       fi
 
 install:


### PR DESCRIPTION
Hi @naokazuterada 

I have given some attention to the failing build. Everything looks very promising, the last part needed is the coverage report, where I observe the following error.

```
==> Collecting reports

    Generating coverage xml reports for Python

    Error running `['/home/travis/virtualenv/python3.7.1/bin/python', '-m', 'coverage', 'xml', '-i']`: Command '['/home/travis/virtualenv/python3.7.1/bin/python', '-m', 'coverage', 'xml', '-i']' returned non-zero exit status 1.

    - Ignored: [Errno 2] No such file or directory: '/home/travis/build/naokazuterada/MarkdownTOC/coverage.xml'

Error: No coverage report found
```

It seems as if `covdecov` cannot locate the generated coverage data, I suspect a path issue, since the data is displayed in the CI log.

Could you give my proposed PR a review ? - I will dig into the remaining issue later unless you can spot it and fix it before me. I just have to squeeze in some work today :-/