### PR TITLE
fix remove_items_in_codeblocks regex for codeblocks nested in lists

### DIFF
--- a/markdowntoc/markdowntoc_insert.py
+++ b/markdowntoc/markdowntoc_insert.py
@@ -407,7 +407,7 @@ class MarkdowntocInsert(sublime_plugin.TextCommand, Base):
 
     def remove_items_in_codeblock(self, items):
 
-        codeblocks = self.view.find_all("^\s*(`{3,}|~{3,})\S*")
+        codeblocks = self.view.find_all("^(\s|[-*])*(`{3,}|~{3,})\S*")
         codeblockAreas = []  # [[area_begin, area_end], ..]
         i = 0
         while i < len(codeblocks) - 1:


### PR DESCRIPTION
<!--
You should use unit-tests for SublimeText by using [UnitTesting](https://github.com/randy3k/UnitTesting) plugin.

1. Install the UnitTesting plugin
2. Comment out or rename your own `MarkdownTOC.sublime-settings` so individual settings are not used during testing
3. [Run tests](https://github.com/randy3k/UnitTesting-example#running-tests)
4. Send Pull Request when tests pass
-->

The current regex within `remove_items_in_codeblock` doesn't properly match codeblocks nested inlists, which results in invalid ToC generation (often meaning large chunks of actual content get incorrectly filtered out due to bad matching between opening/closing code fence backticks)

This PR fixes the regex so that it will correctly match when a codeblock is nested in a list started with `-` or `*`.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/naokazuterada/MarkdownTOC/170)
<!-- Reviewable:end -->
