### PR TITLE
Fix Mapping import for Python 3.14

### DIFF
--- a/markdowntoc/util.py
+++ b/markdowntoc/util.py
@@ -1,4 +1,4 @@
-import collections
+from collections.abc import Mapping
 
 
 class Util:
@@ -73,7 +73,7 @@ class Util:
             if (
                 k in dct
                 and isinstance(dct[k], dict)
-                and isinstance(merge_dct[k], collections.Mapping)
+                and isinstance(merge_dct[k], Mapping)
             ):
                 Util.dict_merge(dct[k], merge_dct[k])
             else:


### PR DESCRIPTION
Fixes #173.

## Summary
- import `Mapping` from `collections.abc` instead of `collections`
- keep the existing recursive settings merge behavior unchanged

## Verification
- `python3 -m py_compile markdowntoc/util.py`
- loaded `markdowntoc/util.py` directly and verified `Util.dict_merge()` still recursively merges nested dict settings
- `git -c core.whitespace=blank-at-eol,blank-at-eof,space-before-tab,cr-at-eol diff --check` (file is CRLF in the repo)

No Sublime Text host, secrets, accounts, deploys, or external services involved.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/naokazuterada/MarkdownTOC/174)
<!-- Reviewable:end -->
